### PR TITLE
Fix propel 1.6 minimum requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
-      env: PROPEL1_VERSION=1.6.* COMPOSER_FLAGS="--prefer-lowest"
+      env: PROPEL1_VERSION="~1.6,>=1.6.6" COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: PROPEL1_VERSION=1.6.*
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,37 @@
 language: php
 
 php:
-    - 5.3.3
-    - 5.3
-    - 5.4
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+  - nightly
+
+env:
+  - PROPEL1_VERSION=1.7.*
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: PROPEL1_VERSION=1.6.* COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: PROPEL1_VERSION=1.6.*
+    - php: 5.6
+      env: PROPEL1_VERSION=1.7.*
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install --dev --prefer-source
+  - composer selfupdate
+  - composer require "propel/propel1:${PROPEL1_VERSION}" --no-update
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
-script: phpunit --coverage-text
+phpunit: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "propel/propel1": "~1.6"
+        "propel/propel1": "~1.6,>=1.6.6"
     },
     "autoload": {
         "classmap": ["src/"]


### PR DESCRIPTION
On master, run `composer update --prefer-lowest` and `phpunit`, you will get:

```
require_once(phing/BuildException.php): failed to open stream: No such file or directory
```

Phing was introduce since propel 1.6.6.

This PR fixes minimum requirements.

I also update Travis to add some tests for prevent it on the future.

Can you please bump a new patch version after merge it? This PR is needed to get the following working: https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/311
